### PR TITLE
Use static library for test executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,22 @@ SET (RELEASE_NAME "Quotes for daily inspiration")
 SET (VERSION "0.5.6")
 SET (VERSION_INFO "Initial release")
 
+SET (APIVERSION 0)
+SET (LIBNAME ${EXEC_NAME}-${APIVERSION})
+SET (LIBVERSION "0")
+SET (SOVERSION 0)
+
+# The path where library files should be searched for
+set (LIBRARY_PATH "src")
+
 FIND_PACKAGE (PkgConfig)
 
 PKG_CHECK_MODULES (DEPS REQUIRED gtk+-3.0 libsoup-2.4 json-glib-1.0)
+SET(APPLICATION_DEPS
+    gtk+-3.0>=3.12
+    libsoup-2.4
+    json-glib-1.0
+)
 
 ADD_DEFINITIONS (${DEPS_CFLAGS})
 LINK_LIBRARIES (${DEPS_LIBRARIES})
@@ -26,20 +39,17 @@ FIND_PACKAGE (Vala REQUIRED)
 INCLUDE (ValaVersion)
 ENSURE_VALA_VERSION ("0.26" MINIMUM)
 
+add_subdirectory (src)
+
 INCLUDE (ValaPrecompile)
 VALA_PRECOMPILE (VALA_C ${EXEC_NAME}
-    src/configs/Constants.vala
-    src/configs/Properties.vala
-    src/utils/QuoteClient.vala
-    src/widgets/Toolbar.vala
-    src/widgets/QuoteStack.vala
-    src/MainWindow.vala
-    src/Application.vala
+    src/Main.vala
 
 PACKAGES
-    gtk+-3.0>=3.12
-    libsoup-2.4
-    json-glib-1.0
+    ${APPLICATION_DEPS}
+    
+CUSTOM_VAPIS
+    ${CMAKE_BINARY_DIR}/${LIBRARY_PATH}/${LIBNAME}_internal.vapi
 )
 
 INCLUDE (GResource)
@@ -50,9 +60,17 @@ GLIB_COMPILE_RESOURCES (GLIB_RESOURCES_CSS SOURCE data/css/css.gresource.xml)
 INCLUDE (GSettings)
 ADD_SCHEMA ("data/com.github.alonsoenrique.quotes.gschema.xml")
 
+# tell cmake what to call the executable we just made
 ADD_EXECUTABLE (${EXEC_NAME} ${VALA_C} ${GLIB_RESOURCES_ICONS} ${GLIB_RESOURCES_CSS})
+add_dependencies (${EXEC_NAME} ${LIBNAME})
+target_link_libraries (${EXEC_NAME} ${DEPS_LIBRARIES} ${LIBNAME})
+
+set_target_properties (${EXEC_NAME} PROPERTIES
+    INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/${LIBRARY_PATH}
+)
 
 INSTALL (TARGETS ${EXEC_NAME} RUNTIME DESTINATION bin)
+
 INSTALL (FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/com.github.alonsoenrique.quotes.desktop DESTINATION ${DATADIR}/applications/)
 INSTALL (FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/com.github.alonsoenrique.quotes.appdata.xml DESTINATION ${DATADIR}/metainfo/)
 

--- a/cmake/ValaPrecompile.cmake
+++ b/cmake/ValaPrecompile.cmake
@@ -1,0 +1,285 @@
+##
+# Copyright 2009-2010 Jakob Westhoff. All rights reserved.
+# Copyright 2012-2016 elementary LLC.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+# 
+#    2. Redistributions in binary form must reproduce the above copyright notice,
+#       this list of conditions and the following disclaimer in the documentation
+#       and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY JAKOB WESTHOFF ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+# EVENT SHALL JAKOB WESTHOFF OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# 
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of Jakob Westhoff
+##
+
+find_package(Vala REQUIRED)
+include(CMakeParseArguments)
+
+##
+# Compile vala files to their c equivalents for further processing. 
+#
+# The "vala_precompile" macro takes care of calling the valac executable on the
+# given source to produce c files which can then be processed further using
+# default cmake functions.
+# 
+# The first parameter provided is a variable, which will be filled with a list
+# of c files outputted by the vala compiler. This list can than be used in
+# conjuction with functions like "add_executable" or others to create the
+# neccessary compile rules with CMake.
+# 
+# The initial variable is followed by a list of .vala files to be compiled.
+# Please take care to add every vala file belonging to the currently compiled
+# project or library as Vala will otherwise not be able to resolve all
+# dependencies.
+# 
+# The following sections may be specified afterwards to provide certain options
+# to the vala compiler:
+# 
+# PACKAGES
+#   A list of vala packages/libraries to be used during the compile cycle. The
+#   package names are exactly the same, as they would be passed to the valac
+#   "--pkg=" option.
+# 
+# OPTIONS
+#   A list of optional options to be passed to the valac executable. This can be
+#   used to pass "--thread" for example to enable multi-threading support.
+#
+# CUSTOM_VAPIS
+#   A list of custom vapi files to be included for compilation. This can be
+#   useful to include freshly created vala libraries without having to install
+#   them in the system.
+#
+# GENERATE_VAPI
+#   Pass all the needed flags to the compiler to create a vapi for
+#   the compiled library. The provided name will be used for this and a
+#   <provided_name>.vapi file will be created.
+#
+# GENERATE_INTERNAL_VAPI
+#   Pass all the needed flags to the compiler to create an internal vapi for
+#   the compiled library. The provided name will be used for this and a
+#   <provided_name>.vapi file will be created. GENERATE_VAPI needs to be used
+#   alongside this.
+#
+# GENERATE_HEADER
+#   Let the compiler generate a header file for the compiled code. A header file
+#   called <provided_name>.h will be generated.
+#
+# GENERATE_INTERNAL_HEADER
+#   Let the compiler generate an internal header file for the compiled code. 
+#   An internal header file called <provided_name>.h will be generated.
+#
+# GENERATE_GIR
+#   Have the compiler generate a GObject-Introspection repository file with
+#   name: <provided_name>.gir. This can be later used to create a binary typelib
+#   using the GI compiler.
+#
+# GENERATE_SYMBOLS
+#   Output a <provided_name>.symbols file containing all the exported symbols.
+# 
+# The following call is a simple example to the vala_precompile macro showing
+# an example to every of the optional sections:
+#
+#   vala_precompile(VALA_C mytargetname
+#       source1.vala
+#       source2.vala
+#       source3.vala
+#   PACKAGES
+#       gtk+-2.0
+#       gio-1.0
+#       posix
+#   DIRECTORY
+#       gen
+#   OPTIONS
+#       --thread
+#   CUSTOM_VAPIS
+#       some_vapi.vapi
+#   GENERATE_VAPI
+#       myvapi
+#   GENERATE_HEADER
+#       myheader
+#   GENERATE_INTERNAL_VAPI
+#       myvapi_internal
+#   GENERATE_INTERNAL_HEADER
+#       myheader_internal
+#   GENERATE_GIR
+#       mygir
+#   GENERATE_SYMBOLS
+#       mysymbols
+#   )
+#
+# Most important is the variable VALA_C which will contain all the generated c
+# file names after the call.
+##
+
+macro(vala_precompile output target_name)
+    cmake_parse_arguments (ARGS "" "GENERATE_GIR;GENERATE_SYMBOLS;GENERATE_HEADER;GENERATE_VAPI;GENERATE_INTERNAL_HEADER;GENERATE_INTERNAL_VAPI;DIRECTORY" "PACKAGES;OPTIONS;CUSTOM_VAPIS" ${ARGN})
+
+    if(ARGS_DIRECTORY)
+        set(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${ARGS_DIRECTORY})
+    else(ARGS_DIRECTORY)
+        set(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    endif(ARGS_DIRECTORY)
+    include_directories(${DIRECTORY})
+    set(vala_pkg_opts "")
+    foreach(pkg ${ARGS_PACKAGES})
+        list(APPEND vala_pkg_opts "--pkg=${pkg}")
+    endforeach(pkg ${ARGS_PACKAGES})
+    set(in_files "")
+    set(out_files "")
+    set(out_files_display "")
+    set(${output} "")
+
+    foreach(src ${ARGS_UNPARSED_ARGUMENTS})
+        string(REGEX MATCH "^/" IS_MATCHED ${src})
+        if(${IS_MATCHED} MATCHES "/")
+            set(src_file_path ${src})
+        else()
+            set(src_file_path ${CMAKE_CURRENT_SOURCE_DIR}/${src})
+        endif()
+        list(APPEND in_files ${src_file_path})
+        string(REPLACE ".vala" ".c" src ${src})
+        string(REPLACE ".gs" ".c" src ${src})
+        if(${IS_MATCHED} MATCHES "/")
+            get_filename_component(VALA_FILE_NAME ${src} NAME)
+            set(out_file "${CMAKE_CURRENT_BINARY_DIR}/${VALA_FILE_NAME}")
+            list(APPEND out_files "${CMAKE_CURRENT_BINARY_DIR}/${VALA_FILE_NAME}")
+        else()
+            set(out_file "${DIRECTORY}/${src}")
+            list(APPEND out_files "${DIRECTORY}/${src}")
+        endif()
+        list(APPEND ${output} ${out_file})
+        list(APPEND out_files_display "${src}")
+    endforeach(src ${ARGS_DEFAULT_ARGS})
+
+    set(custom_vapi_arguments "")
+    if(ARGS_CUSTOM_VAPIS)
+        # Check for relative and absolute paths
+        foreach(vapi ${ARGS_CUSTOM_VAPIS})
+            string(REGEX MATCH "^/" IS_MATCHED ${vapi})
+            if(${IS_MATCHED} MATCHES "/")
+                list(APPEND custom_vapi_arguments ${vapi})
+            else()
+                list(APPEND custom_vapi_arguments ${CMAKE_CURRENT_SOURCE_DIR}/${vapi})
+            endif()
+        endforeach(vapi ${ARGS_CUSTOM_VAPIS})
+    endif(ARGS_CUSTOM_VAPIS)
+
+    set(vapi_arguments "")
+    if(ARGS_GENERATE_VAPI)
+        list(APPEND out_files "${DIRECTORY}/${ARGS_GENERATE_VAPI}.vapi")
+        list(APPEND out_files_display "${ARGS_GENERATE_VAPI}.vapi")
+        list(APPEND vapi_arguments "--library=${ARGS_GENERATE_VAPI}" "--vapi=${ARGS_GENERATE_VAPI}.vapi")
+
+        # Header and internal header is needed to generate internal vapi
+        if (NOT ARGS_GENERATE_HEADER)
+            set(ARGS_GENERATE_HEADER ${ARGS_GENERATE_VAPI})
+        endif(NOT ARGS_GENERATE_HEADER)
+    endif(ARGS_GENERATE_VAPI)
+
+    if(ARGS_GENERATE_INTERNAL_VAPI)
+        if(ARGS_GENERATE_VAPI)
+            list(APPEND out_files "${DIRECTORY}/${ARGS_GENERATE_INTERNAL_VAPI}.vapi")
+            list(APPEND out_files_display "${ARGS_GENERATE_INTERNAL_VAPI}.vapi")
+            list(APPEND vapi_arguments "--internal-vapi=${ARGS_GENERATE_INTERNAL_VAPI}.vapi")
+
+            # Header and internal header is needed to generate internal vapi
+            if (NOT ARGS_GENERATE_INTERNAL_HEADER)
+                set(ARGS_GENERATE_INTERNAL_HEADER ${ARGS_GENERATE_INTERNAL_VAPI})
+            endif(NOT ARGS_GENERATE_INTERNAL_HEADER)
+        else ()
+            message( SEND_ERROR "vala_precompile: GENERATE_VAPI needs to be set to generate an internal vapi file" )
+        endif(ARGS_GENERATE_VAPI)
+    endif(ARGS_GENERATE_INTERNAL_VAPI)
+
+    set(header_arguments "")
+    if(ARGS_GENERATE_HEADER)
+        list(APPEND out_files "${DIRECTORY}/${ARGS_GENERATE_HEADER}.h")
+        list(APPEND out_files_display "${ARGS_GENERATE_HEADER}.h")
+        list(APPEND header_arguments "--header=${ARGS_GENERATE_HEADER}.h")
+    endif(ARGS_GENERATE_HEADER)
+
+    if(ARGS_GENERATE_INTERNAL_HEADER)
+        list(APPEND out_files "${DIRECTORY}/${ARGS_GENERATE_INTERNAL_HEADER}.h")
+        list(APPEND out_files_display "${ARGS_GENERATE_INTERNAL_HEADER}.h")
+        list(APPEND header_arguments "--internal-header=${ARGS_GENERATE_INTERNAL_HEADER}.h")
+    endif(ARGS_GENERATE_INTERNAL_HEADER)
+
+    set(gir_arguments "")
+    set(gircomp_command "")
+    if(ARGS_GENERATE_GIR)
+        list(APPEND out_files "${DIRECTORY}/${ARGS_GENERATE_GIR}.gir")
+        list(APPEND out_files_display "${ARGS_GENERATE_GIR}.gir")
+        set(gir_arguments "--gir=${ARGS_GENERATE_GIR}.gir")
+
+        include (FindGirCompiler)
+        find_package(GirCompiler REQUIRED)
+        
+        set(gircomp_command 
+            COMMAND 
+                ${G_IR_COMPILER_EXECUTABLE}
+            ARGS 
+                "${DIRECTORY}/${ARGS_GENERATE_GIR}.gir"
+                -o "${DIRECTORY}/${ARGS_GENERATE_GIR}.typelib")
+    endif(ARGS_GENERATE_GIR)
+
+    set(symbols_arguments "")
+    if(ARGS_GENERATE_SYMBOLS)
+        list(APPEND out_files "${DIRECTORY}/${ARGS_GENERATE_SYMBOLS}.symbols")
+        list(APPEND out_files_display "${ARGS_GENERATE_SYMBOLS}.symbols")
+        set(symbols_arguments "--symbols=${ARGS_GENERATE_SYMBOLS}.symbols")
+    endif(ARGS_GENERATE_SYMBOLS)
+
+    # Workaround for a bug that would make valac run twice. This file is written
+    # after the vala compiler generates C source code.
+    set(OUTPUT_STAMP ${CMAKE_CURRENT_BINARY_DIR}/${target_name}_valac.stamp)
+
+    add_custom_command(
+    OUTPUT
+        ${OUTPUT_STAMP}
+    COMMAND 
+        ${VALA_EXECUTABLE} 
+    ARGS 
+        "-C" 
+        ${header_arguments} 
+        ${vapi_arguments} 
+        ${gir_arguments} 
+        ${symbols_arguments} 
+        "-b" ${CMAKE_CURRENT_SOURCE_DIR} 
+        "-d" ${DIRECTORY} 
+        ${vala_pkg_opts} 
+        ${ARGS_OPTIONS} 
+        "-g"
+        ${in_files} 
+        ${custom_vapi_arguments}
+    COMMAND
+        touch
+    ARGS
+        ${OUTPUT_STAMP}
+    DEPENDS 
+        ${in_files} 
+        ${ARGS_CUSTOM_VAPIS}
+    COMMENT
+        "Generating ${out_files_display}"
+    ${gircomp_command}
+    )
+
+    # This command will be run twice for some reason (pass a non-empty string to COMMENT
+    # in order to see it). Since valac is not executed from here, this won't be a problem.
+    add_custom_command(OUTPUT ${out_files} DEPENDS ${OUTPUT_STAMP} COMMENT "")
+endmacro(vala_precompile)

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -48,10 +48,6 @@ namespace Quotes {
 			}
 		}
 
-		public static int main(string[] args) {
-			return new Application ().run (args);
-		}
-
 	}
 
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Create Constants.vala
+configure_file (${CMAKE_CURRENT_SOURCE_DIR}/configs/Constants.vala.cmake ${CMAKE_CURRENT_SOURCE_DIR}/configs/Constants.vala)
+
 INCLUDE (ValaPrecompile)
 VALA_PRECOMPILE (VALA_C ${LIBNAME}
     configs/Constants.vala

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,34 @@
+INCLUDE (ValaPrecompile)
+VALA_PRECOMPILE (VALA_C ${LIBNAME}
+    configs/Constants.vala
+    configs/Properties.vala
+    utils/QuoteClient.vala
+    widgets/Toolbar.vala
+    widgets/QuoteStack.vala
+    MainWindow.vala
+    Application.vala
+
+PACKAGES
+    ${APPLICATION_DEPS}
+    
+GENERATE_VAPI
+    ${LIBNAME}
+GENERATE_HEADER
+    ${LIBNAME}
+GENERATE_INTERNAL_VAPI
+    ${LIBNAME}_internal
+GENERATE_INTERNAL_HEADER
+    ${LIBNAME}_internal
+)
+
+set (LIBS ${DEPS_LIBRARIES} -lm)
+set (LIB_PATHS ${DEPS_LIBRARY_DIRS})
+link_directories (${LIB_PATHS})
+
+set (LIB_FILES ${C_SOURCES} ${VALA_C})
+
+add_library (${LIBNAME} STATIC
+    ${LIB_FILES}
+)
+
+target_link_libraries (${LIBNAME} ${LIBS})

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -1,0 +1,3 @@
+public static int main(string[] args) {
+	return new Quotes.Application ().run (args);
+}

--- a/src/configs/Constants.vala.cmake
+++ b/src/configs/Constants.vala.cmake
@@ -24,8 +24,8 @@ namespace Quotes.Configs {
      */
     public class Constants {
 
-        public abstract const string ID = "com.github.alonsoenrique.quotes";
-        public abstract const string VERSION = "0.5.1";
+        public abstract const string ID = "@APP_ID@";
+        public abstract const string VERSION = "@VERSION@";
         public abstract const string PROGRAME_NAME = "Quotes";
         public abstract const string APP_YEARS = "2017";
         public abstract const string APP_ICON = "com.github.alonsoenrique.quotes";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,17 +9,16 @@ vala_precompile (VALA_C ${TEST_EXEC_NAME}
 
 # tell what libraries to use when compiling
 PACKAGES
-    gtk+-3.0
-OPTIONS
-    ${VALAC_OPTIONS}
-# CUSTOM_VAPIS
-#    ${CMAKE_BINARY_DIR}/${LIBRARY_PATH}/${LIBNAME}_internal.vapi
+    ${APPLICATION_DEPS}
+
+CUSTOM_VAPIS
+    ${CMAKE_BINARY_DIR}/${LIBRARY_PATH}/${LIBNAME}_internal.vapi
 )
 
 # tell cmake what to call the executable we just made
 add_executable (${TEST_EXEC_NAME} ${VALA_C})
-# add_dependencies (${TEST_EXEC_NAME} ${LIB_NAME})
-target_link_libraries (${TEST_EXEC_NAME} ${DEPS_LIBRARIES} ${LIB_NAME})
+add_dependencies (${TEST_EXEC_NAME} ${LIBNAME})
+target_link_libraries (${TEST_EXEC_NAME} ${DEPS_LIBRARIES} ${LIBNAME})
 
 set_target_properties (${TEST_EXECUTABLE_NAME} PROPERTIES
     INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/${LIBRARY_PATH}


### PR DESCRIPTION
Using "cmake/ValaPrecompile.cmake" in this pr is not optional as upstream does not include the means to generate internal vapi and header files. (Needed to export private classes, etc...) Maybe I should try to get this change upstream.

If you do not want to use static linking to make the test executable then you can include the vala files from /src directly in tests/CmakeLists.txt. The disadvantage is that you build each object twice.

I also took the liberty to make updating Constants.vala automatic. Right now it only updates ID and VERSION, but this is easy to expand.

I hope that this helps.