### PR TITLE
Fix wrong order of attachment in overlay

### DIFF
--- a/src/Widgets/QuoteStack.vala
+++ b/src/Widgets/QuoteStack.vala
@@ -65,8 +65,8 @@ namespace Quotes.Widgets {
 			quote_box.pack_start (this.quote_url);
 
 			this.quote_overlay = new Gtk.Overlay ();
-			this.quote_overlay.add_overlay (copied_toast);
 			this.quote_overlay.add_overlay (quote_box);
+			this.quote_overlay.add_overlay (copied_toast);
 
 			// Add widgets to Stack
 			this.add_named (this.spinner, "spinner");


### PR DESCRIPTION
I found the top layer in `Gtk.Overlay` must be declared in the last of the code and the bottom one must be in the first of the code, otherwise the clear button in `Granite.Widgets.Toast` won't work.
